### PR TITLE
Warn and abort if pact folder does not exist

### DIFF
--- a/src/main/java/com/github/wrm/pact/maven/UploadPactsMojo.java
+++ b/src/main/java/com/github/wrm/pact/maven/UploadPactsMojo.java
@@ -44,6 +44,12 @@ public class UploadPactsMojo extends AbstractPactsMojo {
     public void execute() throws MojoExecutionException, MojoFailureException {
 
         File folder = new File(pacts);
+
+        if(!folder.exists()){
+           getLog().warn(String.format("pact folder '%s' does not exist", pacts));
+           return;
+        }
+
         getLog().info("loading pacts from " + pacts);
         try {
             List<PactFile> pactList = readPacts(folder);


### PR DESCRIPTION
Currently the plugin fails if the pact folder does not exist. With this change you get a warning, but no exception.
