### PR TITLE
Fix issue when downloading pacts of a provider with no pact link present

### DIFF
--- a/src/main/java/com/github/wrm/pact/repository/BrokerRepositoryProvider.java
+++ b/src/main/java/com/github/wrm/pact/repository/BrokerRepositoryProvider.java
@@ -76,7 +76,8 @@ public class BrokerRepositoryProvider implements RepositoryProvider {
         List<String> links = new ArrayList<>();
 
         if (connection.getResponseCode() != 200) {
-            log.error("Downloading pact links failed. Pact Broker answered with: " + connection.getContent());
+            log.error("Downloading pact links failed. Pact Broker answered with status: " + connection.getResponseCode()
+                    + " and message: " + connection.getResponseMessage());
             return links;
         }
 
@@ -149,7 +150,8 @@ public class BrokerRepositoryProvider implements RepositoryProvider {
         connection.setDoInput(true);
 
         if (connection.getResponseCode() != 200) {
-            log.error("Downloading pact failed. Pact Broker answered with: " + connection.getContent());
+            log.error("Downloading pact failed. Pact Broker answered with status: " + connection.getResponseCode()
+                    + " and message: " + connection.getResponseMessage());
             return;
         }
 

--- a/src/test/java/com/github/wrm/pact/repository/BrokerRepositoryProviderTest.java
+++ b/src/test/java/com/github/wrm/pact/repository/BrokerRepositoryProviderTest.java
@@ -115,6 +115,14 @@ public class BrokerRepositoryProviderTest {
         assertThat(links.get(0), is(pactLink));
     }
 
+    @Test
+    @PactVerification("provider-no-pact-link-present")
+    public void doNotFailDownloadForProviderWithNoPactLinkPresent() throws Exception {
+        List<String> links = brokerRepositoryProvider.downloadPactLinks("provider-no-pact-link-present", null);
+
+        assertThat(links.size(), is(0));
+    }
+
     @Pact(state = "no-pacts-present", provider = "broker-maven-plugin", consumer = "pact-broker")
     public PactFragment createFragmentForUploading(PactDslWithState builder) {
 
@@ -169,6 +177,13 @@ public class BrokerRepositoryProviderTest {
 
         return builder.uponReceiving("a request for the latest provider pacts").path(pactPath).headers(getHeaders())
                 .method("GET").willRespondWith().headers(getHeaders()).status(200).body(pactJson).toFragment();
+    }
+
+    @Pact(state = "provider-no-pact-link-present", provider = "broker-maven-plugin", consumer = "pact-broker")
+    public PactFragment createFragmentForDownloadingPactLinksOfProviderWithNoPactLinkPresent(PactDslWithState builder) {
+        return builder.uponReceiving("a request for the latest pacts of a provider with no link present")
+                .path("/pacts/provider/provider-no-pact-link-present/latest").headers(getHeaders()).method("GET")
+                .willRespondWith().headers(getHeaders()).status(404).toFragment();
     }
 
     private Map<String, String> getHeaders() {


### PR DESCRIPTION
Hi,
I noticed we get an exception when trying to read non-successful responses from the pact broker during download. 
I implemented a fix and tests to cover one of those scenarios.
Cheers
