### PR TITLE
Handling HTTP basic auth for brokers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -181,3 +181,15 @@ or downloading pacts, use the configuration sections as below:
 	  <password>password</password>
     </configuration>
 ```
+
+To provide credentials when using a pact broker with HTTP basic auth, 
+use the configuration sections as below:
+```xml
+    <configuration>
+      <brokerUrl>https://yourbroker.pact.dius.com.au</brokerUrl>
+      <pacts>target/pacts-dependents</pacts>
+	  <provider>provider</provider>
+      <username>user</username>
+	  <password>password</password>
+    </configuration>
+```

--- a/src/main/java/com/github/wrm/pact/maven/AbstractPactsMojo.java
+++ b/src/main/java/com/github/wrm/pact/maven/AbstractPactsMojo.java
@@ -28,7 +28,7 @@ public abstract class AbstractPactsMojo extends AbstractMojo {
             Optional<CredentialsProvider> credentialProvider = getCredentialsProvider(username, password);
             return new GitRepositoryProvider(url, getLog(), credentialProvider);
         }
-        return new BrokerRepositoryProvider(url, consumerVersion, getLog());
+        return new BrokerRepositoryProvider(url, consumerVersion, getLog(), username, password);
     }
 
 

--- a/src/test/java/com/github/wrm/pact/repository/BrokerRepositoryProviderTest.java
+++ b/src/test/java/com/github/wrm/pact/repository/BrokerRepositoryProviderTest.java
@@ -1,5 +1,6 @@
 package com.github.wrm.pact.repository;
 
+import static java.util.Optional.empty;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -55,7 +56,7 @@ public class BrokerRepositoryProviderTest {
         }
         pact = PactFile.readPactFile(pactFile);
         brokerRepositoryProvider = new BrokerRepositoryProvider("http://localhost:" + port, CONSUMER_VERSION,
-                new SystemStreamLog());
+                                                                new SystemStreamLog(), empty(), empty());
     }
 
     @Rule
@@ -76,14 +77,14 @@ public class BrokerRepositoryProviderTest {
     @Test
     @PactVerification("no-pacts-present")
     public void uploadPactToBroker() throws Exception {
-        brokerRepositoryProvider.uploadPacts(Collections.singletonList(pact), Optional.empty());
+        brokerRepositoryProvider.uploadPacts(Collections.singletonList(pact), empty());
     }
 
 
     @Test
     @PactVerification("pact-already-uploaded")
     public void uploadExistingPactToBroker() throws Exception {
-        brokerRepositoryProvider.uploadPacts(Collections.singletonList(pact), Optional.empty());
+        brokerRepositoryProvider.uploadPacts(Collections.singletonList(pact), empty());
     }
 
     @Test


### PR DESCRIPTION
this will enable the plugin to use brokers with HTTP basic auth (for example: https://pact.dius.com.au/ ).