### PR TITLE
Allow multiple tags on uploaded version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.github.warmuuh</groupId>
   <artifactId>pactbroker-maven-plugin</artifactId>
-  <version>0.0.13</version>
+  <version>0.0.14</version>
   <packaging>maven-plugin</packaging>
 
   <properties>

--- a/readme.md
+++ b/readme.md
@@ -24,10 +24,10 @@ cd pactbroker-maven-plugin
 mvn install
 ```
 
-##Usage
+## Usage
 
 
-###Consumer
+### Consumer
 
 Configure plugin in your pom.xml using the *upload-pacts* goal:
 
@@ -37,7 +37,7 @@ Configure plugin in your pom.xml using the *upload-pacts* goal:
     <plugin>
       <groupId>com.github.warmuuh</groupId>
       <artifactId>pactbroker-maven-plugin</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.14</version>
       <executions>
         <execution>
           <id>upload-pacts</id>
@@ -54,7 +54,7 @@ Configure plugin in your pom.xml using the *upload-pacts* goal:
 </build>
 ```
 
-###Producer
+### Producer
 
 Configure plugin in your pom.xml. This time,
 the *download-pacts* goal is used:
@@ -65,7 +65,7 @@ the *download-pacts* goal is used:
     <plugin>
       <groupId>com.github.warmuuh</groupId>
       <artifactId>pactbroker-maven-plugin</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.14</version>
       <executions>
         <execution>
           <id>download-pacts</id>
@@ -82,7 +82,7 @@ the *download-pacts* goal is used:
   </plugins>
 </build>
 ```
-###Having consumer and producer in a multi-module project
+### Having consumer and producer in a multi-module project
 Configure plugin at the parent pom
 ```xml
 <build>
@@ -90,7 +90,7 @@ Configure plugin at the parent pom
       <plugin>
             <groupId>com.github.warmuuh</groupId>
             <artifactId>pactbroker-maven-plugin</artifactId>
-            <version>0.0.10</version>
+            <version>0.0.14</version>
             <executions>
                 <execution>
                     <goals>
@@ -118,7 +118,7 @@ At *generate-test-resources* phase the relevant provider pacts will be downloade
     <plugin>
       <groupId>com.github.warmuuh</groupId>
       <artifactId>pactbroker-maven-plugin</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.14</version>
           <executions>
               <execution>
                   <goals>
@@ -154,7 +154,7 @@ If you are using [scala-pact](https://github.com/ITV/scala-pact) from ITV to gen
     <plugin>
       <groupId>com.github.warmuuh</groupId>
       <artifactId>pactbroker-maven-plugin</artifactId>
-      <version>0.0.10</version>
+      <version>0.0.14</version>
       <executions>
         <execution>
           <id>upload-pacts</id>
@@ -170,15 +170,16 @@ If you are using [scala-pact](https://github.com/ITV/scala-pact) from ITV to gen
   </plugins>
 </build>
 ```
+### Security
 To provide credentials when using git repository while uploading
 or downloading pacts, use the configuration sections as below:
 ```xml
     <configuration>
       <brokerUrl>https://github.com/pact-repo.git</brokerUrl>
       <pacts>target/pacts-dependents</pacts>
-	  <provider>provider</provider>
+      <provider>provider</provider>
       <username>user</username>
-	  <password>password</password>
+      <password>password</password>
     </configuration>
 ```
 
@@ -188,9 +189,77 @@ use the configuration sections as below:
     <configuration>
       <brokerUrl>https://yourbroker.pact.dius.com.au</brokerUrl>
       <pacts>target/pacts-dependents</pacts>
-	  <provider>provider</provider>
+      <provider>provider</provider>
       <username>user</username>
-	  <password>password</password>
+      <password>password</password>
     </configuration>
 ```
-you can also supply `<insecure>true</insecure>` to ignore certificate validation
+You can also supply `<insecure>true</insecure>` to ignore certificate validation.
+
+### Tagging Pacts
+[Tagging pact versions](https://github.com/pact-foundation/pact_broker/wiki/Using-tags) is a useful technique that is supported on pact uploads. There are multiple methods available for you to tag your pacts.
+
+#### From command line
+Running a build and passing a list of tags to the parameter `-Dpact.tagNames` will upload the pacts and tag the version as directed.
+
+For example, running `mvn clean install -Dpact.tagNames=foo,bar,baz` will upload the pacts and tag the uploaded version with the tags "foo", "bar", and "baz".
+
+#### List tags in pom
+This example will upload the pact as version 1.2.3, and tag that version with the tags "foo", "bar", and "baz".
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.github.warmuuh</groupId>
+      <artifactId>pactbroker-maven-plugin</artifactId>
+      <version>0.0.14</version>
+      <executions>
+        <execution>
+          <id>upload-pacts</id>
+          <phase>test</phase>
+          <goals><goal>upload-pacts</goal></goals>
+          <configuration>
+            <brokerUrl>ssh://gitlab/pact-repo.git</brokerUrl>
+            <pacts>${project.build.directory}/pacts</pacts>
+            <consumerVersion>1.2.3</consumerVersion>
+            <tagNames>
+              <tagName>foo</tagName>
+              <tagName>bar</tagName>
+              <tagName>baz</tagName>
+            </tagNames>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```
+
+**Note:** Tag names in the pom will override tags provided from the command line.
+
+#### Single tag (legacy)
+Kept in for backwards compatibility, you can provide a single `tagName` in the pom.
+```xml
+<build>
+  <plugins>
+    <plugin>
+      <groupId>com.github.warmuuh</groupId>
+      <artifactId>pactbroker-maven-plugin</artifactId>
+      <version>0.0.14</version>
+      <executions>
+        <execution>
+          <id>upload-pacts</id>
+          <phase>test</phase>
+          <goals><goal>upload-pacts</goal></goals>
+          <configuration>
+            <brokerUrl>ssh://gitlab/pact-repo.git</brokerUrl>
+            <pacts>${project.build.directory}/pacts</pacts>
+            <consumerVersion>1.2.3</consumerVersion>
+            <tagName>i-am-a-lonely-tag</tagName>
+          </configuration>
+        </execution>
+      </executions>
+    </plugin>
+  </plugins>
+</build>
+```

--- a/src/main/java/com/github/wrm/pact/maven/UploadPactsMojo.java
+++ b/src/main/java/com/github/wrm/pact/maven/UploadPactsMojo.java
@@ -2,9 +2,11 @@ package com.github.wrm.pact.maven;
 
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -59,6 +61,12 @@ public class UploadPactsMojo extends AbstractPactsMojo {
     @Parameter
     private String tagName;
 
+    /**
+     * List of tag names to tag the consumer pact version with
+     */
+    @Parameter(defaultValue = "${pact.tagNames}")
+    private String[] tagNames;
+
     @Parameter(defaultValue = "false")
     private boolean insecure;
 
@@ -89,7 +97,13 @@ public class UploadPactsMojo extends AbstractPactsMojo {
             if (mergePacts)
             	pactList = mergePactsWithSameProviderConsumer(pactList);
             RepositoryProvider provider = createRepositoryProvider(brokerUrl, consumerVersion, Optional.ofNullable(username), Optional.ofNullable(password), insecure);
-            provider.uploadPacts(pactList, Optional.ofNullable(tagName).filter(s -> !s.isEmpty()));
+
+            if(tagNames == null && tagName != null) {
+                tagNames = new String[1];
+                tagNames[0] = tagName;
+            }
+
+            provider.uploadPacts(pactList, Arrays.asList(tagNames).stream().filter(s -> !s.isEmpty()).collect(Collectors.toList()));
         }
         catch (Exception e) {
             throw new MojoExecutionException("Failed to read pacts", e);

--- a/src/main/java/com/github/wrm/pact/repository/BrokerRepositoryProvider.java
+++ b/src/main/java/com/github/wrm/pact/repository/BrokerRepositoryProvider.java
@@ -65,11 +65,11 @@ public class BrokerRepositoryProvider implements RepositoryProvider {
     }
 
     @Override
-    public void uploadPacts(final List<PactFile> pacts, final Optional<String> tagName) throws Exception {
+    public void uploadPacts(final List<PactFile> pacts, final List<String> tagNames) throws Exception {
         for (PactFile pact : pacts) {
             uploadPact(pact);
-            if(tagName.isPresent()) {
-                tagPactVersion(pact, tagName.get());
+            for(String tagName : tagNames) {
+                tagPactVersion(pact, tagName);
             }
         }
     }
@@ -254,7 +254,7 @@ public class BrokerRepositoryProvider implements RepositoryProvider {
     }
 
     private HttpUriRequest createRequest(HttpUriRequest request) {
-        request.setHeader("Accept", "application/json");
+        request.setHeader("Accept", "application/json,application/hal+json");
         request.setHeader("Content-Type", "application/json");
         request.setHeader("charset", StandardCharsets.UTF_8.displayName());
         addBasicAuthTo(request);

--- a/src/main/java/com/github/wrm/pact/repository/GitRepositoryProvider.java
+++ b/src/main/java/com/github/wrm/pact/repository/GitRepositoryProvider.java
@@ -45,8 +45,8 @@ public class GitRepositoryProvider implements RepositoryProvider {
      * *.git/provider/consumer/provider-consumer.json
      */
     @Override
-    public void uploadPacts(List<PactFile> pacts, Optional<String> tagName) throws Exception {
-        if (tagName.isPresent())
+    public void uploadPacts(List<PactFile> pacts, List<String> tagNames) throws Exception {
+        if (!tagNames.isEmpty())
             throw new UnsupportedOperationException("Tag names not supported for git repositories");
         log.info("using pact repository: " + url);
         File repoDir = new File(path);

--- a/src/main/java/com/github/wrm/pact/repository/RepositoryProvider.java
+++ b/src/main/java/com/github/wrm/pact/repository/RepositoryProvider.java
@@ -2,7 +2,6 @@ package com.github.wrm.pact.repository;
 
 import java.io.File;
 import java.util.List;
-import java.util.Optional;
 
 import com.github.wrm.pact.domain.PactFile;
 
@@ -14,7 +13,7 @@ public interface RepositoryProvider {
 	 * @param tagName
 	 * @throws Exception
 	 */
-	void uploadPacts(List<PactFile> pacts, Optional<String> tagName) throws Exception;
+	void uploadPacts(List<PactFile> pacts, List<String> tagName) throws Exception;
 
 	
 	


### PR DESCRIPTION
Often when using tags, teams want to add more than one tag. The existing functionality only supports a single tag name, so I have made a few changes to allow a list of tags to added.

There is the ability to add a list of tags in the pom, and there is also the functionality to pass the list from the command line. This can be useful, for example, if you want to tag your pacts from the master branch as "master", and all feature branches as "dev", along with their branch name.

I have also fixed up a couple of formatting issues on the readme and added tagging instructions, and updated the Accept headers to play nice with the updated broker.